### PR TITLE
Frontend fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,9 @@
   "scripts": {
     "test": "node check.js"
   },
-  "repository" :
-  {
-    "type" : "git",
-    "url" : "https://github.com/hahnmichaelf/esdb-check.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hahnmichaelf/esdb-check.git"
   },
   "keywords": [
     "ethereum",
@@ -25,5 +24,8 @@
   "dependencies": {
     "json": "^9.0.6",
     "request": "^2.87.0"
+  },
+  "browser": {
+    "json": false
   }
 }


### PR DESCRIPTION
JSON package doesn't work on the frontend. So esdb-check package doesn't work on frontend too. This change adds the ability to run esdb-check in the frontend.